### PR TITLE
Fixing Java warnings and testing VSCode

### DIFF
--- a/EduBot/src/test/java/xbot/edubot/TogglePrecisionDriveCommandTest.java
+++ b/EduBot/src/test/java/xbot/edubot/TogglePrecisionDriveCommandTest.java
@@ -7,7 +7,7 @@ import xbot.edubot.operator_interface.OperatorInterface;
 import xbot.edubot.subsystems.drive.DriveSubsystem;
 import xbot.edubot.subsystems.drive.commands.TankDriveWithJoysticksCommand;
 import xbot.edubot.subsystems.drive.commands.TogglePrecisionDriveCommand;
-import xbot.common.controls.sensors.mock_adapters.MockJoystick;
+//import xbot.common.controls.sensors.mock_adapters.MockJoystick;
 import xbot.common.math.XYPair;
 
 public class TogglePrecisionDriveCommandTest extends BaseDriveTest {

--- a/EduBot/src/test/java/xbot/edubot/linear/LinearVisualizationPanel.java
+++ b/EduBot/src/test/java/xbot/edubot/linear/LinearVisualizationPanel.java
@@ -11,6 +11,7 @@ import javax.swing.JPanel;
 import xbot.common.math.XYPair;
 
 public class LinearVisualizationPanel extends JPanel {
+    private static final long serialVersionUID = 473984572055979398L;
     private int centerX;
     private int centerY;
     private String loops = "0";

--- a/EduBot/src/test/java/xbot/edubot/rotation/RotationTestVisualizer.java
+++ b/EduBot/src/test/java/xbot/edubot/rotation/RotationTestVisualizer.java
@@ -20,7 +20,7 @@ public class RotationTestVisualizer {
     BaseOrientationEngineTest currentTestEnvironment;
     RotationEnvironmentState envState = new RotationEnvironmentState();
     private JPanel controlPanel;
-    private JComboBox testSelectionBox;
+    private JComboBox<OrientationTest> testSelectionBox;
     private JSlider speedSlider;
 
     /**
@@ -65,7 +65,7 @@ public class RotationTestVisualizer {
         controlPanel = new JPanel();
         splitPane.setRightComponent(controlPanel);
         
-        testSelectionBox = new JComboBox();
+        testSelectionBox = new JComboBox<OrientationTest>();
         testSelectionBox.addItemListener((e) -> {
             if(e.getStateChange() == ItemEvent.SELECTED) {
                 setOrientationTest((OrientationTest)e.getItem());
@@ -73,7 +73,7 @@ public class RotationTestVisualizer {
         });
         
         controlPanel.setLayout(new FlowLayout(FlowLayout.CENTER, 5, 5));
-        testSelectionBox.setModel(new DefaultComboBoxModel(OrientationTest.values()));
+        testSelectionBox.setModel(new DefaultComboBoxModel<OrientationTest>(OrientationTest.values()));
         testSelectionBox.setSelectedIndex(0);
         controlPanel.add(testSelectionBox);
         

--- a/EduBot/src/test/java/xbot/edubot/rotation/RotationVisualizationPanel.java
+++ b/EduBot/src/test/java/xbot/edubot/rotation/RotationVisualizationPanel.java
@@ -12,6 +12,7 @@ import xbot.common.math.XYPair;
 import xbot.edubot.rotation.BaseOrientationEngineTest.RotationEnvironmentState;
 
 public class RotationVisualizationPanel extends JPanel {
+    private static final long serialVersionUID = 2785468671430694763L;
     private int centerX;
     private int centerY;
     private XYPair center;

--- a/Workspace.code-workspace
+++ b/Workspace.code-workspace
@@ -1,8 +1,11 @@
 {
-	"folders": [
-		{
-			"path": "."
-		}
+    "folders": [
+        {
+            "path": "EduBot"
+        },
+        {
+            "path": "SeriouslyCommonLib"
+        }
     ],
     "settings": {
         "java.configuration.updateBuildConfiguration": "automatic",


### PR DESCRIPTION
Warnings:
- Unused imports
- Adding serialization UIDs
- No longer using raw types for RotationTestVisualizer