### PR TITLE
Feature/no tests for pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,8 +29,8 @@ jobs:
       inputs:
         gradleWrapperFile: 'gradlew'
         gradleOptions: '-Xmx3072m'
-        publishJUnitResults: true
-        testResultsFiles: '**/TEST-*.xml'
+        publishJUnitResults: false
+        # testResultsFiles: '**/TEST-*.xml'
         tasks: 'build --stacktrace --info -x test'
         # checkStyleRunAnalysis: true
         # pmdRunAnalysis: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ jobs:
         gradleOptions: '-Xmx3072m'
         publishJUnitResults: true
         testResultsFiles: '**/TEST-*.xml'
-        tasks: 'build --stacktrace --info'
+        tasks: 'build --stacktrace --info -x test'
         # checkStyleRunAnalysis: true
         # pmdRunAnalysis: true
     - task: PublishCodeCoverageResults@1


### PR DESCRIPTION
Disables tests for the integration build, since we know we have a pile of tests that will fail.