### PR TITLE
Add a few more test cases to go to orientation test

### DIFF
--- a/src/test/java/xbot/edubot/rotation/GoToOrientationTest.java
+++ b/src/test/java/xbot/edubot/rotation/GoToOrientationTest.java
@@ -10,7 +10,7 @@ import xbot.edubot.rotation.RotationTestVisualizer.SelectableOrientationTest;
 public class GoToOrientationTest extends BaseOrientationEngineTest implements SelectableOrientationTest {
 
     @Test
-    public void testGoToOrientation() {
+    public void testGoToOrientation0to150() {
         DriveToOrientationCommand command = injector.getInstance(DriveToOrientationCommand.class);
         command.setTargetHeading(150);
 
@@ -18,11 +18,35 @@ public class GoToOrientationTest extends BaseOrientationEngineTest implements Se
         runTestEnv();
     }
 
+    @Test
+    public void testGoToOrientation0toNeg150() {
+        DriveToOrientationCommand command = injector.getInstance(DriveToOrientationCommand.class);
+        command.setTargetHeading(150);
+
+        setUpTestEnvironment(command, 0, -150);
+        runTestEnv();
+    }
+
+    @Test
+    public void testGoToOrientationNeg90to150() {
+        DriveToOrientationCommand command = injector.getInstance(DriveToOrientationCommand.class);
+        command.setTargetHeading(150);
+
+        setUpTestEnvironment(command, -90, 150);
+        runTestEnv();
+    }
+
     @Override
     public void invokeOrientationTest(OrientationTest test) {
         switch (test) {
-            case ROTATE_TO_ORIENTATION:
-                this.testGoToOrientation();
+            case ROTATE_TO_ORIENTATION_0_150:
+                this.testGoToOrientation0to150();
+                break;
+            case ROTATE_TO_ORIENTATION_0_NEG_150:
+                this.testGoToOrientation0toNeg150();
+                break;
+            case ROTATE_TO_ORIENTATION_NEG_90_150:
+                this.testGoToOrientationNeg90to150();
                 break;
             default:
                 throw new RuntimeException("The requested orientation test is not available in this test class.");

--- a/src/test/java/xbot/edubot/rotation/RotationTestVisualizer.java
+++ b/src/test/java/xbot/edubot/rotation/RotationTestVisualizer.java
@@ -99,7 +99,9 @@ public class RotationTestVisualizer {
             case GO_LEFT_90_FROM_NEG_90:
                 currentTestEnvironment = new TurnLeft90DegreesCommandTest();
                 break;
-            case ROTATE_TO_ORIENTATION:
+            case ROTATE_TO_ORIENTATION_0_150:
+            case ROTATE_TO_ORIENTATION_0_NEG_150:
+            case ROTATE_TO_ORIENTATION_NEG_90_150:
                 currentTestEnvironment = new GoToOrientationTest();
                 break;
             default:
@@ -130,7 +132,9 @@ public class RotationTestVisualizer {
         GO_LEFT_90_FROM_NEG_90,
         GO_LEFT_90_FROM_NEG_150,
         GO_LEFT_90_FROM_150,
-        ROTATE_TO_ORIENTATION
+        ROTATE_TO_ORIENTATION_0_150,
+        ROTATE_TO_ORIENTATION_0_NEG_150,
+        ROTATE_TO_ORIENTATION_NEG_90_150,
     }
     
     public static interface SelectableOrientationTest {


### PR DESCRIPTION
We only had the 1 case and it doesn't highlight awkward wrap-around issues. This adds negative numbers and going from negative to positive the short-way (instead of looping all the way around the long way).

![image](https://user-images.githubusercontent.com/399279/179429166-dba091e4-68f7-4bee-933d-4a55cf0f0e51.png)

![image](https://user-images.githubusercontent.com/399279/179429170-dfdce7b0-dd40-4a06-9039-7d71893df9be.png)
