### PR TITLE
Increase usage of Dagger Injection in the EDU tests

### DIFF
--- a/.idea/runConfigurations/LinearTestVisualizer.xml
+++ b/.idea/runConfigurations/LinearTestVisualizer.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="LinearTestVisualizer" type="Application" factoryName="Application" nameIsGenerated="true">
+    <option name="MAIN_CLASS_NAME" value="xbot.edubot.linear.LinearTestVisualizer" />
+    <module name="XbotEdu.test" />
+    <option name="WORKING_DIRECTORY" value="./build/jni/release" />
+    <extension name="coverage">
+      <pattern>
+        <option name="PATTERN" value="xbot.edubot.linear.*" />
+        <option name="ENABLED" value="true" />
+      </pattern>
+    </extension>
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.idea/runConfigurations/RotationTestVisualizer.xml
+++ b/.idea/runConfigurations/RotationTestVisualizer.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="RotationTestVisualizer" type="Application" factoryName="Application" nameIsGenerated="true">
+    <option name="MAIN_CLASS_NAME" value="xbot.edubot.rotation.RotationTestVisualizer" />
+    <module name="XbotEdu.test" />
+    <option name="WORKING_DIRECTORY" value="./build/jni/release" />
+    <extension name="coverage">
+      <pattern>
+        <option name="PATTERN" value="xbot.edubot.rotation.*" />
+        <option name="ENABLED" value="true" />
+      </pattern>
+    </extension>
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/src/test/java/competition/subsystems/drive/ArcadeDriveTest.java
+++ b/src/test/java/competition/subsystems/drive/ArcadeDriveTest.java
@@ -5,7 +5,6 @@ import org.junit.Test;
 import xbot.common.command.BaseCommand;
 import xbot.common.math.XYPair;
 import competition.operator_interface.OperatorInterface;
-import competition.subsystems.drive.commands.ArcadeDriveWithJoysticksCommand;
 import edu.wpi.first.wpilibj.MockXboxControllerAdapter;
 
 public class ArcadeDriveTest extends BaseDriveTest {
@@ -13,8 +12,7 @@ public class ArcadeDriveTest extends BaseDriveTest {
     @Test
     public void test() {
         OperatorInterface oi = this.getInjectorComponent().operatorInterface();
-
-        BaseCommand command = new ArcadeDriveWithJoysticksCommand(this.drive);
+        BaseCommand command = this.getInjectorComponent().arcadeDriveWithJoysticksCommand();
 
         MockXboxControllerAdapter left = (MockXboxControllerAdapter) oi.gamepad;
 

--- a/src/test/java/competition/subsystems/drive/TankDriveTest.java
+++ b/src/test/java/competition/subsystems/drive/TankDriveTest.java
@@ -10,7 +10,7 @@ public class TankDriveTest extends BaseDriveTest {
 
     @Test
     public void test() {
-        final BaseCommand command = new TankDriveWithJoysticksCommand(this.drive, this.oi);
+        final BaseCommand command = this.getInjectorComponent().tankDriveWithJoysticksCommand();
 
         // Call the TankDriveWithJoysticksCommand initialize once
         command.initialize();

--- a/src/test/java/competition/subsystems/drive/TogglePrecisionDriveCommandTest.java
+++ b/src/test/java/competition/subsystems/drive/TogglePrecisionDriveCommandTest.java
@@ -11,8 +11,8 @@ public class TogglePrecisionDriveCommandTest extends BaseDriveTest {
 
     @Test
     public void test() {
-        BaseCommand driveCommand = new TankDriveWithJoysticksCommand(drive, oi);
-        BaseCommand togglePrecisionCommand = new TogglePrecisionDriveCommand(drive);
+        BaseCommand driveCommand = this.getInjectorComponent().tankDriveWithJoysticksCommand();
+        BaseCommand togglePrecisionCommand = this.getInjectorComponent().togglePrecisionDriveCommand();
 
         driveCommand.initialize();
 

--- a/src/test/java/injection/components/CompetitionTestComponent.java
+++ b/src/test/java/injection/components/CompetitionTestComponent.java
@@ -4,6 +4,7 @@ import javax.inject.Singleton;
 
 import competition.injection.components.BaseRobotComponent;
 import competition.injection.modules.SimulatedRobotModule;
+import competition.subsystems.drive.commands.*;
 import dagger.Component;
 import xbot.common.injection.modules.MockControlsModule;
 import xbot.common.injection.modules.MockDevicesModule;
@@ -13,4 +14,15 @@ import xbot.common.injection.modules.UnitTestModule;
 @Component(modules = { UnitTestModule.class, MockDevicesModule.class, MockControlsModule.class, SimulatedRobotModule.class })
 public abstract class CompetitionTestComponent extends BaseRobotComponent {
 
+    public abstract ArcadeDriveWithJoysticksCommand arcadeDriveWithJoysticksCommand();
+
+    public abstract TankDriveWithJoysticksCommand tankDriveWithJoysticksCommand();
+
+    public abstract TogglePrecisionDriveCommand togglePrecisionDriveCommand();
+
+    public abstract DriveToPositionCommand driveToPositionCommand();
+
+    public abstract TurnLeft90DegreesCommand turnLeft90DegreesCommand();
+
+    public abstract DriveToOrientationCommand driveToOrientationCommand();
 }

--- a/src/test/java/xbot/edubot/linear/DriveToPositionCommandTest.java
+++ b/src/test/java/xbot/edubot/linear/DriveToPositionCommandTest.java
@@ -53,8 +53,8 @@ public class DriveToPositionCommandTest extends BaseDriveTest {
     }
     
     public void vizRun() {
-        command = 
-                new DriveToPositionCommand(this.drive, this.pose);
+        command = this.getInjectorComponent().driveToPositionCommand();
+
         command.setTargetPosition(target_distance);
                 
         command.initialize();

--- a/src/test/java/xbot/edubot/rotation/BaseOrientationEngineTest.java
+++ b/src/test/java/xbot/edubot/rotation/BaseOrientationEngineTest.java
@@ -47,7 +47,7 @@ public class BaseOrientationEngineTest extends BaseDriveTest {
         else if (targetYaw < -180) {
             targetYaw += 360;
         }
-        setUpTestEnvironment(new TurnLeft90DegreesCommand(this.drive, this.pose), initialYaw, targetYaw);
+        setUpTestEnvironment(this.getInjectorComponent().turnLeft90DegreesCommand(), initialYaw, targetYaw);
     }
 
     protected void runTestEnv() {

--- a/src/test/java/xbot/edubot/rotation/GoToOrientationTest.java
+++ b/src/test/java/xbot/edubot/rotation/GoToOrientationTest.java
@@ -11,7 +11,7 @@ public class GoToOrientationTest extends BaseOrientationEngineTest implements Se
 
     @Test
     public void testGoToOrientation0to150() {
-        DriveToOrientationCommand command = new DriveToOrientationCommand(this.drive);
+        DriveToOrientationCommand command = this.getInjectorComponent().driveToOrientationCommand();
         command.setTargetHeading(150);
 
         setUpTestEnvironment(command, 0, 150);
@@ -20,7 +20,7 @@ public class GoToOrientationTest extends BaseOrientationEngineTest implements Se
 
     @Test
     public void testGoToOrientation0toNeg150() {
-        DriveToOrientationCommand command = new DriveToOrientationCommand(this.drive);
+        DriveToOrientationCommand command = this.getInjectorComponent().driveToOrientationCommand();
         command.setTargetHeading(-150);
 
         setUpTestEnvironment(command, 0, -150);
@@ -29,7 +29,7 @@ public class GoToOrientationTest extends BaseOrientationEngineTest implements Se
 
     @Test
     public void testGoToOrientationNeg90to150() {
-        DriveToOrientationCommand command = new DriveToOrientationCommand(this.drive);
+        DriveToOrientationCommand command = this.getInjectorComponent().driveToOrientationCommand();
         command.setTargetHeading(150);
 
         setUpTestEnvironment(command, -90, 150);


### PR DESCRIPTION
- Tests now use injection to get their commands, rather than creating them via "new". This should avoid issues where students add new constructor dependencies in their commands and the tests blow up.

- Also adds IntelliJ run configurations for the visualizers (as long as ".\gradlew build" was run once) that points to the JNI directory as a working directory