### PR TITLE
Only run tests expected to pass by default with gradle

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ jobs:
         gradleOptions: '-Xmx3072m'
         publishJUnitResults: false
         # testResultsFiles: '**/TEST-*.xml'
-        tasks: 'build --stacktrace --info -x test'
+        tasks: 'build --stacktrace --info'
         # checkStyleRunAnalysis: true
         # pmdRunAnalysis: true
     - task: PublishCodeCoverageResults@1

--- a/build.gradle
+++ b/build.gradle
@@ -199,6 +199,11 @@ task checkstyle(type: Checkstyle) {
 }
 
 test {
+    filter {
+        includeTestsMatching "*basic_understanding*"
+        includeTestsMatching "*RobotInitTest*"
+    }
+
     reports {
         junitXml.required = true
     }               


### PR DESCRIPTION
Right now most of the tests in this project are expected to fail at first (until the student has completed that challenge). However by default gradle will run all these tests, including when just doing an initial `build` action which we ask students to do at first to seed the dagger stuff. However since this is expected to fail it makes it hard to debug at first glance if something went wrong or not without going to read the message.

This PR proposes that gradle only run the tests that are expected to pass initially. The others that fail (the actual curriculum ones) can still be run directly from vscode as we suggest.

This will also let us setup CI on this project more meaningfully.