### PR TITLE
fix order of calling execute() in unit tests

### DIFF
--- a/src/test/java/competition/subsystems/drive/TogglePrecisionDriveCommandTest.java
+++ b/src/test/java/competition/subsystems/drive/TogglePrecisionDriveCommandTest.java
@@ -18,9 +18,7 @@ public class TogglePrecisionDriveCommandTest extends BaseDriveTest {
 
         togglePrecisionCommand.initialize();
 
-        if (!togglePrecisionCommand.isFinished()) {
-            togglePrecisionCommand.execute();
-        }
+        togglePrecisionCommand.execute();
         gamepad.setLeftStick(new XYPair(0, 1.0));
         gamepad.setRightStick(new XYPair(0, 1.0));
         driveCommand.execute();
@@ -35,9 +33,8 @@ public class TogglePrecisionDriveCommandTest extends BaseDriveTest {
         this.assertDrive(-0.5, -0.5);
 
         togglePrecisionCommand.initialize();
-        if (!togglePrecisionCommand.isFinished()) {
-            togglePrecisionCommand.execute();
-        }
+        togglePrecisionCommand.execute();
+ 
         gamepad.setLeftStick(new XYPair(0, 1.0));
         gamepad.setRightStick(new XYPair(0, 1.0));
         driveCommand.execute();

--- a/src/test/java/xbot/edubot/linear/DriveToPositionCommandTest.java
+++ b/src/test/java/xbot/edubot/linear/DriveToPositionCommandTest.java
@@ -129,12 +129,13 @@ public class DriveToPositionCommandTest extends BaseDriveTest {
                 + getForwardPower()
             );
             
+            command.execute();
+            
             if(command.isFinished()) {
                 isFinished = true;
                 break;
             }
             
-            command.execute();
             
         }
         

--- a/src/test/java/xbot/edubot/rotation/BaseOrientationEngineTest.java
+++ b/src/test/java/xbot/edubot/rotation/BaseOrientationEngineTest.java
@@ -63,11 +63,11 @@ public class BaseOrientationEngineTest extends BaseDriveTest {
             System.out.printf("Time:%.1f sec, TurningPower:%.2f, Velocity:%.2f, Yaw:%.2f \n", (double) i * BASE_TIME_STEP,
                     getRotationPower(), engine.getVelocity(), engine.getOrientation());
 
+            currentRotationCommand.execute();
             if (currentRotationCommand.isFinished()) {
                 break;
             }
 
-            currentRotationCommand.execute();
         }
 
         assertTrue("Verify command reports successfully finished", currentRotationCommand.isFinished());


### PR DESCRIPTION
# Whats changing?
Turns out that execute() is called before isFinished not after in each command scheduler run loop. This PR updates our unit tests to match that behavior

# Questions/notes for reviewers

# How did you test this?
